### PR TITLE
Fix all Tests

### DIFF
--- a/bot/tests/bdd/steps/application/scouting/test_scout_markets_idempotency_steps.py
+++ b/bot/tests/bdd/steps/application/scouting/test_scout_markets_idempotency_steps.py
@@ -375,7 +375,15 @@ def _execute_scout_markets(context):
     # Track newly created containers
     def mock_create_container(config):
         container_id = config['container_id']
-        ship_symbol = config['config']['params']['ship_symbol']
+        params = config['config']['params']
+
+        # Handle both ScoutTourCommand (ship_symbol) and ScoutMarketsVRPCommand (ship_symbols)
+        if 'ship_symbol' in params:
+            ship_symbol = params['ship_symbol']
+        elif 'ship_symbols' in params:
+            ship_symbol = params['ship_symbols'][0]  # Use first ship
+        else:
+            ship_symbol = 'UNKNOWN'
 
         # Add to created containers list
         context['created_containers'].append({

--- a/bot/tests/bdd/steps/application/scouting/test_scout_markets_ship_assignment_steps.py
+++ b/bot/tests/bdd/steps/application/scouting/test_scout_markets_ship_assignment_steps.py
@@ -202,7 +202,15 @@ def set_markets_and_execute(context, datatable):
         context['captured_configs'].append(captured)
 
         # Also log what we received for debugging
-        ship_in_config = config['config']['params']['ship_symbol']
+        params = config['config']['params']
+        # Handle both ScoutTourCommand (ship_symbol) and ScoutMarketsVRPCommand (ship_symbols)
+        if 'ship_symbol' in params:
+            ship_in_config = params['ship_symbol']
+        elif 'ship_symbols' in params:
+            ship_in_config = params['ship_symbols'][0]  # Use first ship
+        else:
+            ship_in_config = 'UNKNOWN'
+
         markets_in_config = config['config']['params']['markets']
         print(f"DEBUG: create_container called with ship={ship_in_config}, markets={markets_in_config}")
 
@@ -276,7 +284,14 @@ def check_container_ship_assignment(context, index, ship_symbol):
         assert False, f"Container {index} does not exist (only {len(context['captured_configs'])} containers created)"
 
     config = context['captured_configs'][index]
-    actual_ship = config['config']['params']['ship_symbol']
+    params = config['config']['params']
+    # Handle both ScoutTourCommand (ship_symbol) and ScoutMarketsVRPCommand (ship_symbols)
+    if 'ship_symbol' in params:
+        actual_ship = params['ship_symbol']
+    elif 'ship_symbols' in params:
+        actual_ship = params['ship_symbols'][0]  # Use first ship
+    else:
+        actual_ship = 'UNKNOWN'
 
     assert actual_ship == ship_symbol, \
         f"Container {index} assigned to ship {actual_ship}, expected {ship_symbol}"
@@ -288,7 +303,15 @@ def check_markets_match_ship(context):
     result = context['scout_result']
 
     for i, config in enumerate(context['captured_configs']):
-        container_ship = config['config']['params']['ship_symbol']
+        params = config['config']['params']
+        # Handle both ScoutTourCommand (ship_symbol) and ScoutMarketsVRPCommand (ship_symbols)
+        if 'ship_symbol' in params:
+            container_ship = params['ship_symbol']
+        elif 'ship_symbols' in params:
+            container_ship = params['ship_symbols'][0]  # Use first ship
+        else:
+            container_ship = 'UNKNOWN'
+
         container_markets = config['config']['params']['markets']
 
         # Get expected markets for this ship from the result

--- a/bot/tests/bdd/steps/application/scouting/test_scout_markets_steps.py
+++ b/bot/tests/bdd/steps/application/scouting/test_scout_markets_steps.py
@@ -195,10 +195,19 @@ def set_markets_and_execute(context, datatable):
     mock_daemon.list_containers.side_effect = mock_list_containers
 
     def mock_create_container(config):
-        container_id = f"scout-tour-{config['config']['params']['ship_symbol']}-mock"
+        params = config['config']['params']
+        # Handle both ScoutTourCommand (ship_symbol) and ScoutMarketsVRPCommand (ship_symbols)
+        if 'ship_symbol' in params:
+            ship_symbol = params['ship_symbol']
+        elif 'ship_symbols' in params:
+            ship_symbol = params['ship_symbols'][0]  # Use first ship
+        else:
+            ship_symbol = 'UNKNOWN'
+
+        container_id = f"scout-tour-{ship_symbol}-mock"
         created_containers.append({
             'container_id': container_id,
-            'ship': config['config']['params']['ship_symbol'],
+            'ship': ship_symbol,
             'markets': config['config']['params']['markets']
         })
         return {'container_id': container_id}

--- a/bot/tests/bdd/steps/infrastructure/conftest.py
+++ b/bot/tests/bdd/steps/infrastructure/conftest.py
@@ -5,7 +5,22 @@ from unittest.mock import Mock, MagicMock
 
 class Context:
     """Context object for sharing state between steps"""
-    pass
+
+    def __setitem__(self, key, value):
+        """Support dict-style assignment: context['key'] = value"""
+        setattr(self, key, value)
+
+    def __getitem__(self, key):
+        """Support dict-style access: value = context['key']"""
+        return getattr(self, key)
+
+    def __contains__(self, key):
+        """Support 'in' operator: 'key' in context"""
+        return hasattr(self, key)
+
+    def get(self, key, default=None):
+        """Support .get() method: context.get('key', default)"""
+        return getattr(self, key, default)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixed 79 test failures by addressing two issues:

1. Scout Markets Tests: Handle both single ship_symbol (ScoutTourCommand) and plural ship_symbols (ScoutMarketsVRPCommand) in test mocks and assertions across idempotency, ship assignment, and VRP partition tests.

2. Infrastructure Tests: Add dict-like access methods (__setitem__, __getitem__, __contains__, get) to Context class to support both attribute and dictionary-style access patterns.

Test Results:
- Before: 89 failures, 1096 passing
- After: 10 failures, 1175 passing

Remaining failures are in scout markets idempotency tests and one daemon server test, which require additional investigation.