### PR TITLE
feat: complete WaypointCache BDD tests

### DIFF
--- a/gobot/test/bdd/bdd_test.go
+++ b/gobot/test/bdd/bdd_test.go
@@ -76,7 +76,7 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	steps.InitializeScoutMarketsScenario(sc)
 
 	// Infrastructure layer scenarios
-	// steps.InitializeWaypointCacheScenario(sc) // Temporarily disabled - 211 undefined steps
+	steps.InitializeWaypointCacheScenario(sc) // Re-enabled
 	steps.InitializeDatabaseRetryScenario(sc)
 
 	// Daemon layer scenarios

--- a/gobot/test/bdd/features/infrastructure/waypoint_cache.feature
+++ b/gobot/test/bdd/features/infrastructure/waypoint_cache.feature
@@ -57,9 +57,9 @@ Feature: Waypoint Caching
 
   Scenario: Filter waypoints by trait (MARKETPLACE)
     Given waypoints exist in database for system "X1-GZ7":
-      | symbol     | type    | x    | y    | traits           | has_fuel |
-      | X1-GZ7-A1  | PLANET  | 10.0 | 5.0  | SHIPYARD,MARKET  | true     |
-      | X1-GZ7-B2  | MOON    | -5.0 | 8.0  | MARKETPLACE      | false    |
+      | symbol     | type    | x    | y    | traits                 | has_fuel |
+      | X1-GZ7-A1  | PLANET  | 10.0 | 5.0  | SHIPYARD,MARKETPLACE   | true     |
+      | X1-GZ7-B2  | MOON    | -5.0 | 8.0  | MARKETPLACE            | false    |
     When I filter waypoints for system "X1-GZ7" by trait "MARKETPLACE"
     Then I should receive 2 waypoints
     And the waypoint list should contain "X1-GZ7-A1"


### PR DESCRIPTION
Enable and fix WaypointCache test suite:
- Fix getCellValue helper to properly parse table headers
- Update iShouldReceiveNWaypoints to return errors instead of using assertions
- Fix waypoint_cache.feature MARKETPLACE scenario to use correct trait
- Enable WaypointCache test suite in bdd_test.go

All 14 waypoint cache scenarios now passing:
- Save single waypoint to database
- Save multiple waypoints (batch insert)
- Retrieve cached waypoint by symbol
- List all waypoints in a system
- Filter waypoints by trait (SHIPYARD)
- Filter waypoints by trait (MARKETPLACE)
- Filter waypoints by type (PLANET)
- Filter waypoints by has_fuel flag
- Return empty list when no waypoints match trait filter
- Return empty list when no waypoints match type filter
- Upsert waypoint (update existing with new data)
- Preserve waypoint orbitals when saving
- Preserve waypoint coordinates accurately (no rounding errors)
- Deduplication by symbol (same symbol overwrites)