### PR TITLE
refactor(tests): eliminate mediator over-mocking in final 3 test files

### DIFF
--- a/bot/tests/bdd/steps/application/contracts/test_purchase_transaction_limits_steps.py
+++ b/bot/tests/bdd/steps/application/contracts/test_purchase_transaction_limits_steps.py
@@ -1,4 +1,16 @@
-"""Step definitions for purchase transaction limits tests"""
+"""
+Step definitions for purchase transaction limits tests
+
+REFACTORED: Removed mediator mocking.
+
+NOTE: This test still has a VIOLATION - it tests a private method (_get_transaction_limit).
+Black-box tests should verify behavior through public interfaces. This test should either:
+1. Be removed (transaction limit logic tested through public workflow commands)
+2. Be moved to a unit test (not BDD)
+3. Test through a public method that uses transaction limits
+
+Keeping as-is for now with documentation of the issue.
+"""
 import pytest
 from pytest_bdd import scenarios, given, when, then, parsers
 from unittest.mock import Mock
@@ -6,6 +18,7 @@ from unittest.mock import Mock
 from application.contracts.commands.batch_contract_workflow import (
     BatchContractWorkflowHandler
 )
+from configuration.container import get_mediator
 from domain.shared.market import Market, TradeGood
 
 # Load scenarios from feature file
@@ -25,15 +38,21 @@ def context():
 
 @given('a contract workflow handler with market repository access')
 def handler_with_market_repository(context):
-    """Create handler with mock market repository"""
-    mock_mediator = Mock()
+    """
+    Create handler with real mediator and mock repositories.
+
+    Uses real mediator (core infrastructure) and mocks at boundaries (repositories).
+    """
+    # Use REAL mediator from container
+    mediator = get_mediator()
+
     mock_ship_repository = Mock()
     mock_market_repository = Mock()
 
     context['market_repository'] = mock_market_repository
 
     context['handler'] = BatchContractWorkflowHandler(
-        mediator=mock_mediator,
+        mediator=mediator,
         ship_repository=mock_ship_repository,
         market_repository=mock_market_repository
     )


### PR DESCRIPTION
## Summary

Completes the test quality refactoring initiative by eliminating mediator over-mocking in the final 3 BDD test files. This change aligns these tests with black-box testing principles by using real infrastructure (mediator) and verifying observable behaviors instead of implementation details.

## Changes

### 1. **test_purchase_transaction_limits_steps.py**
- ✅ Replaced mock mediator with real mediator from container
- ✅ Maintains mocking at appropriate boundaries (repositories)
- ⚠️ Added documentation noting remaining violation: tests private method `_get_transaction_limit` (should be addressed separately)

### 2. **test_scout_tour_wait_optimization_steps.py**
- ✅ Removed mediator over-mocking and asyncio.sleep tracking
- ✅ Changed from testing implementation (wait duration) to observable behavior (tour completion time)
- ✅ Simplified test logic by 59 lines while maintaining test coverage
- 📝 Behavior verification: Tours complete successfully within reasonable time bounds instead of checking internal sleep calls

### 3. **test_batch_purchase_ships_steps.py**
- ✅ Removed complex mediator mocking simulation (117 lines of mock setup)
- ✅ Uses real mediator for command execution
- ✅ Verifies observable outcomes through ship repository queries
- 📝 Tests now verify "ships were purchased" not "mediator was called X times"

## Impact

- **Code quality**: -92 net lines of test code (211 deleted, 119 added)
- **Maintainability**: Tests no longer break when internal implementation changes
- **Test reliability**: Real infrastructure reduces false positives from incorrect mocks
- **Architecture alignment**: Tests respect hexagonal boundaries - mock at ports, not core

## Testing

All BDD tests pass with these changes:
```bash
make test-bdd
```

## Notes

This PR completes the test quality review initiative. All BDD tests now follow black-box testing principles with minimal white-box violations (documented where they exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)