### PR TITLE
Fix All Failing Tests

### DIFF
--- a/gobot/go.mod
+++ b/gobot/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/cucumber/godog v0.15.1
+	github.com/cucumber/messages/go/v21 v21.0.1
 	github.com/go-playground/validator/v10 v10.28.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
@@ -20,7 +21,6 @@ require (
 
 require (
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
-	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect

--- a/gobot/test/bdd/bdd_test.go
+++ b/gobot/test/bdd/bdd_test.go
@@ -28,12 +28,14 @@ func InitializeScenario(sc *godog.ScenarioContext) {
 	// NOTE: ValueObjectScenarios registered FIRST so its step definitions take precedence
 	// for shared steps like "the result should be true/false"
 	steps.InitializeValueObjectScenarios(sc)
+	// NOTE: Route scenario registered early to ensure its step definitions take precedence
+	// for shared steps like "the operation should fail with error" in route tests
+	steps.InitializeRouteScenario(sc)
+	steps.InitializeShipScenario(sc)
 	// NOTE: ContainerLifecycleScenario registered BEFORE ContainerScenario so lifecycle steps take precedence
 	// The lifecycle steps have the same wording but operate on containerLifecycleContext with currentContainer
 	steps.InitializeContainerLifecycleScenario(sc)
 	steps.InitializeContainerScenario(sc)
-	steps.InitializeShipScenario(sc)
-	steps.InitializeRouteScenario(sc)
 	// Market scouting domain scenarios
 	// NOTE: MarketScenario (trading) registered FIRST to take precedence for simpler patterns
 	// TradeGoodSteps and ScoutingMarketSteps check sharedErr for cross-context error assertions

--- a/gobot/test/bdd/steps/daemon_server_steps.go
+++ b/gobot/test/bdd/steps/daemon_server_steps.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -320,7 +321,33 @@ func (ctx *daemonServerContext) iStartTheDaemonServerOnSocket(socketPath string)
 }
 
 func (ctx *daemonServerContext) iAttemptToStartTheDaemonServerOnInvalidSocket(socketPath string) error {
-	return ctx.iStartTheDaemonServerOnSocket(socketPath)
+	ctx.socketPath = socketPath
+
+	// Do NOT create the directory - this is testing an invalid path
+	// The daemon should fail to create the socket
+
+	// Create daemon server
+	server, err := grpc.NewDaemonServer(ctx.mediator, ctx.logRepo, socketPath)
+	if err != nil {
+		ctx.startErr = err
+		return nil
+	}
+
+	ctx.server = server
+	ctx.startErr = nil
+
+	// Start server in background
+	go func() {
+		err := server.Start()
+		if err != nil {
+			ctx.startErr = err
+		}
+	}()
+
+	// Give server time to attempt start
+	time.Sleep(100 * time.Millisecond)
+
+	return nil
 }
 
 func (ctx *daemonServerContext) aGRPCClientConnectsToTheUnixSocket() error {
@@ -444,13 +471,19 @@ func (ctx *daemonServerContext) theUnixSocketShouldExistAt(socketPath string) er
 	return nil
 }
 
-func (ctx *daemonServerContext) theSocketPermissionsShouldBe(expectedPerms int) error {
+func (ctx *daemonServerContext) theSocketPermissionsShouldBe(expectedPermsStr string) error {
+	// Parse as octal (e.g., "0600" -> 384 in decimal)
+	expectedPerms, err := strconv.ParseInt(expectedPermsStr, 8, 32)
+	if err != nil {
+		return fmt.Errorf("failed to parse permissions %s as octal: %v", expectedPermsStr, err)
+	}
+
 	info, err := os.Stat(ctx.socketPath)
 	if err != nil {
 		return err
 	}
 	actualPerms := int(info.Mode().Perm())
-	if actualPerms != expectedPerms {
+	if actualPerms != int(expectedPerms) {
 		return fmt.Errorf("expected socket permissions %o, got %o", expectedPerms, actualPerms)
 	}
 	return nil

--- a/gobot/test/bdd/steps/route_steps.go
+++ b/gobot/test/bdd/steps/route_steps.go
@@ -355,11 +355,17 @@ func (rc *routeContext) theCurrentSegmentIndexShouldBe(expectedIndex int) error 
 }
 
 func (rc *routeContext) theOperationShouldFailWithError(expectedError string) error {
-	if rc.err == nil {
+	// Check both local context error and shared error (for cross-context assertions)
+	actualErr := rc.err
+	if actualErr == nil {
+		actualErr = sharedErr // Check shared error from other contexts (e.g., value object validation)
+	}
+
+	if actualErr == nil {
 		return fmt.Errorf("expected error containing '%s' but got no error", expectedError)
 	}
-	if !strings.Contains(rc.err.Error(), expectedError) {
-		return fmt.Errorf("expected error containing '%s' but got '%s'", expectedError, rc.err.Error())
+	if !strings.Contains(actualErr.Error(), expectedError) {
+		return fmt.Errorf("expected error containing '%s' but got '%s'", expectedError, actualErr.Error())
 	}
 	return nil
 }

--- a/gobot/test/bdd/steps/ship_steps.go
+++ b/gobot/test/bdd/steps/ship_steps.go
@@ -421,11 +421,17 @@ func (sc *shipContext) iAttemptToEnsureTheShipIsDocked() error {
 }
 
 func (sc *shipContext) theOperationShouldFailWithError(expectedError string) error {
-	if sc.err == nil {
+	// Check both local context error and shared error (for cross-context assertions)
+	actualErr := sc.err
+	if actualErr == nil {
+		actualErr = sharedErr // Check shared error from other contexts (e.g., value object validation)
+	}
+
+	if actualErr == nil {
 		return fmt.Errorf("expected error containing '%s' but got no error", expectedError)
 	}
-	if !strings.Contains(sc.err.Error(), expectedError) {
-		return fmt.Errorf("expected error containing '%s' but got '%s'", expectedError, sc.err.Error())
+	if !strings.Contains(actualErr.Error(), expectedError) {
+		return fmt.Errorf("expected error containing '%s' but got '%s'", expectedError, actualErr.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
Fixed 7 failing BDD tests by addressing step definition conflicts and improving error handling in test contexts:

**Test Initialization Order:**
- Reordered scenario initialization to prevent step definition collisions
- Moved RouteScenario before ShipScenario and ContainerScenario to ensure route-specific steps take precedence in route tests
- This fixes route execution tests that were incorrectly calling container or ship step definitions

**Shared Error Handling:**
- Updated route and ship contexts' `theOperationShouldFailWithError` to check both local context errors and sharedErr (for cross-context assertions)
- Aligns with existing pattern used in market and container contexts
- Fixes fuel value object tests that set sharedErr but were checked by route context steps

**Daemon Socket Permissions:**
- Fixed socket permissions test to parse octal values correctly
- Changed step implementation to accept string and parse as octal (base 8) instead of decimal
- Fixes test expecting "0600" (octal) being compared as 600 (decimal)

**Tests Fixed:**
- Cannot_start_execution_when_already_executing
- Cannot_start_execution_when_completed
- Cannot_complete_segment_when_not_executing
- Consume_fuel_with_negative_amount_raises_error
- Consume_fuel_more_than_available_raises_error
- Consume_negative_fuel_fails
- Daemon_server_starts_and_listens_on_Unix_socket

**Remaining Issues:**
22 tests still failing, primarily in:
- Ship assignment (11 tests)
- Navigation/routing (4 tests)
- Waypoint cache (5 tests)
- Daemon edge cases (1 test)
- Player resolution (1 test)