### PR TITLE
Implement ultrathink feature

### DIFF
--- a/gobot/internal/adapters/api/ship_repository.go
+++ b/gobot/internal/adapters/api/ship_repository.go
@@ -288,6 +288,13 @@ func (r *ShipRepository) shipDataToDomain(ctx context.Context, data *navigation.
 		return nil, fmt.Errorf("failed to create cargo: %w", err)
 	}
 
+	// Convert modules
+	var modules []*navigation.ShipModule
+	for _, mod := range data.Modules {
+		module := navigation.NewShipModule(mod.Symbol, mod.Capacity, mod.Range)
+		modules = append(modules, module)
+	}
+
 	// Convert nav status
 	navStatus := navigation.NavStatus(data.NavStatus)
 
@@ -303,6 +310,7 @@ func (r *ShipRepository) shipDataToDomain(ctx context.Context, data *navigation.
 		data.EngineSpeed,
 		data.FrameSymbol,
 		data.Role,
+		modules,
 		navStatus,
 	)
 }

--- a/gobot/internal/adapters/cli/daemon_client.go
+++ b/gobot/internal/adapters/cli/daemon_client.go
@@ -48,6 +48,16 @@ type RefuelResponse struct {
 	Status      string
 }
 
+type JumpResponse struct {
+	Success           bool
+	NavigatedToGate   bool
+	JumpGateSymbol    string
+	DestinationSystem string
+	CooldownSeconds   int32
+	Message           string
+	Error             string
+}
+
 type BatchContractWorkflowResponse struct {
 	ContainerID string
 	ShipSymbol  string
@@ -286,6 +296,39 @@ func (c *DaemonClient) RefuelShip(
 		FuelAdded:   resp.FuelAdded,
 		CreditsCost: resp.CreditsCost,
 		Status:      resp.Status,
+	}, nil
+}
+
+// JumpShip executes a jump to a different star system via jump gate
+func (c *DaemonClient) JumpShip(
+	ctx context.Context,
+	shipSymbol string,
+	destinationSystem string,
+	playerID int,
+	agentSymbol string,
+) (*JumpResponse, error) {
+	req := &pb.JumpShipRequest{
+		ShipSymbol:        shipSymbol,
+		DestinationSystem: destinationSystem,
+		PlayerId:          int32(playerID),
+	}
+	if agentSymbol != "" {
+		req.AgentSymbol = &agentSymbol
+	}
+
+	resp, err := c.client.JumpShip(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("gRPC call failed: %w", err)
+	}
+
+	return &JumpResponse{
+		Success:           resp.Success,
+		NavigatedToGate:   resp.NavigatedToGate,
+		JumpGateSymbol:    resp.JumpGateSymbol,
+		DestinationSystem: resp.DestinationSystem,
+		CooldownSeconds:   resp.CooldownSeconds,
+		Message:           resp.Message,
+		Error:             resp.Error,
 	}, nil
 }
 

--- a/gobot/internal/application/ship/commands/jump_ship.go
+++ b/gobot/internal/application/ship/commands/jump_ship.go
@@ -1,0 +1,197 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/andrescamacho/spacetraders-go/internal/application/common"
+	"github.com/andrescamacho/spacetraders-go/internal/application/ship/queries"
+	domainNavigation "github.com/andrescamacho/spacetraders-go/internal/domain/navigation"
+	"github.com/andrescamacho/spacetraders-go/internal/domain/player"
+	"github.com/andrescamacho/spacetraders-go/internal/domain/ports"
+)
+
+// JumpShipCommand represents a command to jump a ship to a different system
+type JumpShipCommand struct {
+	ShipSymbol        string // Required: ship symbol to jump
+	DestinationSystem string // Required: destination system symbol
+	PlayerID          *int   // Optional: player ID
+	AgentSymbol       string // Optional: agent symbol
+}
+
+// JumpShipResponse represents the result of a jump operation
+type JumpShipResponse struct {
+	Success            bool
+	NavigatedToGate    bool
+	JumpGateSymbol     string
+	DestinationSystem  string
+	CooldownSeconds    int
+	Message            string
+}
+
+// JumpShipHandler handles the JumpShip command with auto-navigation
+type JumpShipHandler struct {
+	shipRepo       domainNavigation.ShipRepository
+	playerRepo     player.PlayerRepository
+	apiClient      ports.APIClient
+	mediator       common.Mediator
+	playerResolver *common.PlayerResolver
+}
+
+// NewJumpShipHandler creates a new JumpShipHandler
+func NewJumpShipHandler(
+	shipRepo domainNavigation.ShipRepository,
+	playerRepo player.PlayerRepository,
+	apiClient ports.APIClient,
+	mediator common.Mediator,
+) *JumpShipHandler {
+	return &JumpShipHandler{
+		shipRepo:       shipRepo,
+		playerRepo:     playerRepo,
+		apiClient:      apiClient,
+		mediator:       mediator,
+		playerResolver: common.NewPlayerResolver(playerRepo),
+	}
+}
+
+// Handle executes the JumpShip command
+func (h *JumpShipHandler) Handle(ctx context.Context, request common.Request) (common.Response, error) {
+	cmd, ok := request.(*JumpShipCommand)
+	if !ok {
+		return nil, fmt.Errorf("invalid request type: expected *JumpShipCommand")
+	}
+
+	if cmd.ShipSymbol == "" {
+		return nil, fmt.Errorf("ship_symbol is required")
+	}
+
+	if cmd.DestinationSystem == "" {
+		return nil, fmt.Errorf("destination_system is required")
+	}
+
+	playerID, err := h.playerResolver.ResolvePlayerID(ctx, cmd.PlayerID, cmd.AgentSymbol)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := common.LoggerFromContext(ctx)
+	logger.Log("INFO", "Starting jump operation", map[string]interface{}{
+		"ship":        cmd.ShipSymbol,
+		"destination": cmd.DestinationSystem,
+	})
+
+	// 1. Fetch ship from repository
+	ship, err := h.shipRepo.FindBySymbol(ctx, cmd.ShipSymbol, playerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ship: %w", err)
+	}
+
+	// 2. Validate ship has jump drive module
+	if !ship.HasJumpDrive() {
+		return nil, fmt.Errorf("ship %s does not have a jump drive module", cmd.ShipSymbol)
+	}
+
+	logger.Log("INFO", "Ship has jump drive", map[string]interface{}{
+		"range": ship.GetJumpDriveRange(),
+	})
+
+	// 3. Check if ship is at a jump gate
+	currentLocation := ship.CurrentLocation()
+	currentSystem := currentLocation.SystemSymbol
+	navigatedToGate := false
+	jumpGateSymbol := currentLocation.Symbol
+
+	if !currentLocation.IsJumpGate() {
+		logger.Log("INFO", "Ship not at jump gate, finding nearest", map[string]interface{}{
+			"current": currentLocation.Symbol,
+		})
+
+		// 4. Find nearest jump gate
+		playerIDInt := playerID.Value()
+		findQuery := &queries.FindNearestJumpGateQuery{
+			ShipSymbol: cmd.ShipSymbol,
+			PlayerID:   &playerIDInt,
+		}
+
+		findResult, err := h.mediator.Send(ctx, findQuery)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find jump gate: %w", err)
+		}
+
+		findResp, ok := findResult.(*queries.FindNearestJumpGateResponse)
+		if !ok {
+			return nil, fmt.Errorf("unexpected response type from FindNearestJumpGate")
+		}
+
+		jumpGateSymbol = findResp.JumpGate.Symbol
+		logger.Log("INFO", "Found nearest jump gate", map[string]interface{}{
+			"gate":     jumpGateSymbol,
+			"distance": findResp.Distance,
+		})
+
+		// 5. Navigate to jump gate using existing NavigateRouteCommand
+		navCmd := &NavigateRouteCommand{
+			ShipSymbol:  cmd.ShipSymbol,
+			Destination: jumpGateSymbol,
+			PlayerID:    playerID,
+		}
+
+		_, err = h.mediator.Send(ctx, navCmd)
+		if err != nil {
+			return nil, fmt.Errorf("failed to navigate to jump gate: %w", err)
+		}
+
+		navigatedToGate = true
+		logger.Log("INFO", "Navigated to jump gate", map[string]interface{}{
+			"gate": jumpGateSymbol,
+		})
+
+		// 6. Reload ship after navigation
+		ship, err = h.shipRepo.FindBySymbol(ctx, cmd.ShipSymbol, playerID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reload ship after navigation: %w", err)
+		}
+	} else {
+		logger.Log("INFO", "Ship already at jump gate", map[string]interface{}{
+			"gate": currentLocation.Symbol,
+		})
+	}
+
+	// 7. Verify ship is now at jump gate
+	if !ship.CurrentLocation().IsJumpGate() {
+		return nil, fmt.Errorf("ship is not at a jump gate after navigation")
+	}
+
+	// 8. Execute jump via API
+	// Get player to obtain token
+	playerEntity, err := h.playerRepo.FindByID(ctx, playerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get player: %w", err)
+	}
+
+	logger.Log("INFO", "Executing jump", map[string]interface{}{
+		"from": currentSystem,
+		"to":   cmd.DestinationSystem,
+	})
+
+	jumpResult, err := h.apiClient.JumpShip(ctx, cmd.ShipSymbol, cmd.DestinationSystem, playerEntity.Token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute jump: %w", err)
+	}
+
+	logger.Log("INFO", "Jump successful", map[string]interface{}{
+		"destination_system":   jumpResult.DestinationSystem,
+		"destination_waypoint": jumpResult.DestinationWaypoint,
+		"cooldown":             jumpResult.CooldownSeconds,
+	})
+
+	// 9. Return success response
+	return &JumpShipResponse{
+		Success:           true,
+		NavigatedToGate:   navigatedToGate,
+		JumpGateSymbol:    jumpGateSymbol,
+		DestinationSystem: jumpResult.DestinationSystem,
+		CooldownSeconds:   jumpResult.CooldownSeconds,
+		Message:           fmt.Sprintf("Ship %s jumped from %s to %s", cmd.ShipSymbol, currentSystem, jumpResult.DestinationSystem),
+	}, nil
+}

--- a/gobot/internal/application/ship/queries/find_nearest_jump_gate.go
+++ b/gobot/internal/application/ship/queries/find_nearest_jump_gate.go
@@ -1,0 +1,99 @@
+package queries
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/andrescamacho/spacetraders-go/internal/application/common"
+	"github.com/andrescamacho/spacetraders-go/internal/domain/navigation"
+	"github.com/andrescamacho/spacetraders-go/internal/domain/player"
+	"github.com/andrescamacho/spacetraders-go/internal/domain/shared"
+	"github.com/andrescamacho/spacetraders-go/internal/domain/system"
+)
+
+// FindNearestJumpGateQuery represents a query to find the nearest jump gate
+type FindNearestJumpGateQuery struct {
+	ShipSymbol  string // Required: ship symbol to find jump gate for
+	PlayerID    *int   // Optional: query by player ID
+	AgentSymbol string // Optional: query by agent symbol
+}
+
+// FindNearestJumpGateResponse represents the result of finding the nearest jump gate
+type FindNearestJumpGateResponse struct {
+	JumpGate      *shared.Waypoint
+	Distance      float64
+	SystemSymbol  string
+}
+
+// FindNearestJumpGateHandler handles the FindNearestJumpGate query
+type FindNearestJumpGateHandler struct {
+	shipRepo       navigation.ShipRepository
+	graphProvider  system.ISystemGraphProvider
+	playerResolver *common.PlayerResolver
+}
+
+// NewFindNearestJumpGateHandler creates a new FindNearestJumpGateHandler
+func NewFindNearestJumpGateHandler(
+	shipRepo navigation.ShipRepository,
+	graphProvider system.ISystemGraphProvider,
+	playerRepo player.PlayerRepository,
+) *FindNearestJumpGateHandler {
+	return &FindNearestJumpGateHandler{
+		shipRepo:       shipRepo,
+		graphProvider:  graphProvider,
+		playerResolver: common.NewPlayerResolver(playerRepo),
+	}
+}
+
+// Handle executes the FindNearestJumpGate query
+func (h *FindNearestJumpGateHandler) Handle(ctx context.Context, request common.Request) (common.Response, error) {
+	query, ok := request.(*FindNearestJumpGateQuery)
+	if !ok {
+		return nil, fmt.Errorf("invalid request type: expected *FindNearestJumpGateQuery")
+	}
+
+	if query.ShipSymbol == "" {
+		return nil, fmt.Errorf("ship_symbol is required")
+	}
+
+	playerID, err := h.playerResolver.ResolvePlayerID(ctx, query.PlayerID, query.AgentSymbol)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get ship to determine current location and system
+	ship, err := h.shipRepo.FindBySymbol(ctx, query.ShipSymbol, playerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ship: %w", err)
+	}
+
+	currentLocation := ship.CurrentLocation()
+	systemSymbol := currentLocation.SystemSymbol
+
+	// Get system graph to access all waypoints
+	graphResult, err := h.graphProvider.GetGraph(ctx, systemSymbol, false, playerID.Value())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get system graph for %s: %w", systemSymbol, err)
+	}
+
+	// Filter for jump gates
+	var jumpGates []*shared.Waypoint
+	for _, waypoint := range graphResult.Graph.Waypoints {
+		if waypoint.IsJumpGate() {
+			jumpGates = append(jumpGates, waypoint)
+		}
+	}
+
+	if len(jumpGates) == 0 {
+		return nil, fmt.Errorf("no jump gates found in system %s", systemSymbol)
+	}
+
+	// Find nearest jump gate
+	nearest, distance := shared.FindNearestWaypoint(currentLocation, jumpGates)
+
+	return &FindNearestJumpGateResponse{
+		JumpGate:     nearest,
+		Distance:     distance,
+		SystemSymbol: systemSymbol,
+	}, nil
+}

--- a/gobot/internal/application/shipyard/commands/purchase_ship.go
+++ b/gobot/internal/application/shipyard/commands/purchase_ship.go
@@ -538,6 +538,13 @@ func (h *PurchaseShipHandler) convertShipDataToEntity(
 		return nil, err
 	}
 
+	// Convert modules
+	var modules []*navigation.ShipModule
+	for _, mod := range shipData.Modules {
+		module := navigation.NewShipModule(mod.Symbol, mod.Capacity, mod.Range)
+		modules = append(modules, module)
+	}
+
 	ship, err := navigation.NewShip(
 		shipData.Symbol,
 		playerID,
@@ -549,6 +556,7 @@ func (h *PurchaseShipHandler) convertShipDataToEntity(
 		shipData.EngineSpeed,
 		shipData.FrameSymbol,
 		shipData.Role,
+		modules,
 		navStatus,
 	)
 	if err != nil {

--- a/gobot/internal/domain/navigation/ports.go
+++ b/gobot/internal/domain/navigation/ports.go
@@ -79,9 +79,16 @@ type ShipData struct {
 	CargoCapacity int
 	CargoUnits    int
 	EngineSpeed   int
-	FrameSymbol   string // Frame type (e.g., "FRAME_PROBE", "FRAME_DRONE", "FRAME_MINER")
-	Role          string // Ship role from registration (e.g., "EXCAVATOR", "COMMAND", "SATELLITE")
+	FrameSymbol   string       // Frame type (e.g., "FRAME_PROBE", "FRAME_DRONE", "FRAME_MINER")
+	Role          string       // Ship role from registration (e.g., "EXCAVATOR", "COMMAND", "SATELLITE")
+	Modules       []ModuleData // Installed ship modules (jump drives, mining equipment, etc.)
 	Cargo         *CargoData
+}
+
+type ModuleData struct {
+	Symbol   string
+	Capacity int
+	Range    int
 }
 
 type CargoData struct {

--- a/gobot/internal/domain/navigation/ship.go
+++ b/gobot/internal/domain/navigation/ship.go
@@ -54,6 +54,7 @@ type Ship struct {
 	engineSpeed        int
 	frameSymbol        string // Frame type (e.g., "FRAME_PROBE", "FRAME_DRONE", "FRAME_MINER")
 	role               string // Ship role from registration (e.g., "EXCAVATOR", "COMMAND", "SATELLITE")
+	modules            []*ShipModule // Installed ship modules (jump drives, mining equipment, etc.)
 	navStatus          NavStatus
 	fuelService        *ShipFuelService
 	navigationCalc     *ShipNavigationCalculator
@@ -71,6 +72,7 @@ func NewShip(
 	engineSpeed int,
 	frameSymbol string,
 	role string,
+	modules []*ShipModule,
 	navStatus NavStatus,
 ) (*Ship, error) {
 	s := &Ship{
@@ -84,6 +86,7 @@ func NewShip(
 		engineSpeed:     engineSpeed,
 		frameSymbol:     frameSymbol,
 		role:            role,
+		modules:         modules,
 		navStatus:       navStatus,
 		fuelService:     NewShipFuelService(),
 		navigationCalc:  NewShipNavigationCalculator(),
@@ -202,6 +205,31 @@ func (s *Ship) Role() string {
 	return s.role
 }
 
+// Modules returns the ship's installed modules
+func (s *Ship) Modules() []*ShipModule {
+	return s.modules
+}
+
+// HasJumpDrive checks if ship has any jump drive module installed
+func (s *Ship) HasJumpDrive() bool {
+	for _, module := range s.modules {
+		if module.IsJumpDrive() {
+			return true
+		}
+	}
+	return false
+}
+
+// GetJumpDriveRange returns the range of the ship's jump drive, or 0 if none
+func (s *Ship) GetJumpDriveRange() int {
+	for _, module := range s.modules {
+		if module.IsJumpDrive() {
+			return module.Range()
+		}
+	}
+	return 0
+}
+
 // CloneAtLocation creates a copy of the ship at a different location with specified fuel
 // This is used for route planning to simulate ship state at intermediate waypoints
 func (s *Ship) CloneAtLocation(location *shared.Waypoint, currentFuel int) *Ship {
@@ -219,6 +247,7 @@ func (s *Ship) CloneAtLocation(location *shared.Waypoint, currentFuel int) *Ship
 		engineSpeed:    s.engineSpeed,
 		frameSymbol:    s.frameSymbol,
 		role:           s.role,
+		modules:        s.modules, // Share modules (immutable)
 		navStatus:      NavStatusInOrbit, // Assume in orbit for routing
 		fuelService:    s.fuelService,
 		navigationCalc: s.navigationCalc,

--- a/gobot/internal/domain/navigation/ship_module.go
+++ b/gobot/internal/domain/navigation/ship_module.go
@@ -1,0 +1,47 @@
+package navigation
+
+import "strings"
+
+// ShipModule represents an installed module on a ship
+//
+// Modules provide various capabilities to ships such as jump drives,
+// mining lasers, cargo bays, etc. This value object is immutable.
+//
+// Invariants:
+// - Symbol must be non-empty
+// - Capacity and Range cannot be negative
+type ShipModule struct {
+	symbol   string
+	capacity int
+	range_   int // use range_ to avoid Go keyword
+}
+
+// NewShipModule creates a new ShipModule value object
+func NewShipModule(symbol string, capacity, range_ int) *ShipModule {
+	return &ShipModule{
+		symbol:   symbol,
+		capacity: capacity,
+		range_:   range_,
+	}
+}
+
+// Symbol returns the module symbol identifier (e.g., "MODULE_JUMP_DRIVE_I")
+func (m *ShipModule) Symbol() string {
+	return m.symbol
+}
+
+// Capacity returns the module's capacity (if applicable)
+func (m *ShipModule) Capacity() int {
+	return m.capacity
+}
+
+// Range returns the module's range (if applicable)
+func (m *ShipModule) Range() int {
+	return m.range_
+}
+
+// IsJumpDrive checks if this module is a jump drive
+// Jump drive modules have symbols starting with "MODULE_JUMP_DRIVE"
+func (m *ShipModule) IsJumpDrive() bool {
+	return strings.HasPrefix(m.symbol, "MODULE_JUMP_DRIVE")
+}

--- a/gobot/internal/domain/ports/api_client.go
+++ b/gobot/internal/domain/ports/api_client.go
@@ -42,6 +42,10 @@ type APIClient interface {
 	DockShip(ctx context.Context, symbol, token string) error
 	RefuelShip(ctx context.Context, symbol, token string, units *int) (*navigation.RefuelResult, error)
 	SetFlightMode(ctx context.Context, symbol, flightMode, token string) error
+	JumpShip(ctx context.Context, shipSymbol, systemSymbol, token string) (*JumpResult, error)
+
+	// Jump gate operations
+	GetJumpGate(ctx context.Context, systemSymbol, waypointSymbol, token string) (*JumpGateData, error)
 
 	// Player operations
 	GetAgent(ctx context.Context, token string) (*player.AgentData, error)
@@ -136,6 +140,19 @@ type TransferResult struct {
 	GoodSymbol       string
 	UnitsTransferred int
 	RemainingCargo   *navigation.CargoData // Remaining cargo on source ship
+}
+
+// Jump DTOs
+type JumpResult struct {
+	DestinationSystem   string
+	DestinationWaypoint string
+	CooldownSeconds     int
+	TotalPrice          int
+}
+
+type JumpGateData struct {
+	Symbol      string
+	Connections []string
 }
 
 // Market DTOs

--- a/gobot/internal/domain/shared/waypoint.go
+++ b/gobot/internal/domain/shared/waypoint.go
@@ -123,6 +123,14 @@ func (w *Waypoint) IsUncharted() bool {
 	return w.HasTrait("UNCHARTED")
 }
 
+// IsJumpGate checks if this waypoint is a jump gate.
+//
+// Jump gates allow ships to travel between star systems.
+// Ships must be at a jump gate waypoint to execute a jump.
+func (w *Waypoint) IsJumpGate() bool {
+	return w.Type == "JUMP_GATE"
+}
+
 // ExtractSystemSymbol extracts the system symbol from a waypoint symbol
 // by finding the last hyphen and returning everything before it.
 // Example: "X1-AB12-C3D4" -> "X1-AB12"

--- a/gobot/pkg/proto/daemon/daemon.proto
+++ b/gobot/pkg/proto/daemon/daemon.proto
@@ -19,6 +19,9 @@ service DaemonService {
   // RefuelShip refuels a ship at its current location
   rpc RefuelShip(RefuelShipRequest) returns (RefuelShipResponse);
 
+  // JumpShip executes a jump to a different star system via jump gate
+  rpc JumpShip(JumpShipRequest) returns (JumpShipResponse);
+
   // BatchContractWorkflow executes batch contract workflow operations
   rpc BatchContractWorkflow(BatchContractWorkflowRequest) returns (BatchContractWorkflowResponse);
 
@@ -155,6 +158,24 @@ message RefuelShipResponse {
   int32 fuel_added = 3;
   int32 credits_cost = 4;
   string status = 5;
+}
+
+// JumpShipRequest initiates a jump to another system
+message JumpShipRequest {
+  string ship_symbol = 1;
+  string destination_system = 2;
+  int32 player_id = 3;
+  optional string agent_symbol = 4;
+}
+
+message JumpShipResponse {
+  bool success = 1;
+  bool navigated_to_gate = 2;
+  string jump_gate_symbol = 3;
+  string destination_system = 4;
+  int32 cooldown_seconds = 5;
+  string message = 6;
+  string error = 7;
 }
 
 // BatchContractWorkflowRequest initiates batch contract workflow


### PR DESCRIPTION
This commit implements the complete jump-between-systems feature according to the implementation plan in JUMP_BETWEEN_SYSTEMS_IMPLEMENTATION_PLAN.md

Domain Layer:
- Created ShipModule value object for ship module management
- Added Modules field to Ship entity with HasJumpDrive() and GetJumpDriveRange() methods
- Added IsJumpGate() method to Waypoint for jump gate detection

Application Layer:
- Implemented FindNearestJumpGate query handler to find nearest jump gate in system
- Implemented JumpShip command handler with automatic navigation to jump gates
- Orchestrates multi-step process: validate jump drive, find/navigate to gate, execute jump

Adapter Layer:
- Added JumpShip() and GetJumpGate() methods to API client
- Updated GetShip() to include ship modules in response
- Added ship module parsing in ship repository
- Updated protobuf definitions with JumpShip RPC
- Implemented gRPC handler for JumpShip service
- Created CLI jump command with user-friendly output

Features:
- Auto-navigation to nearest jump gate if ship not at one
- Jump drive module validation before jump
- Cooldown tracking and display
- Comprehensive error handling
- Follows hexagonal architecture pattern

Note: Protobuf code generation requires 'protoc' to be installed. Run 'make proto' to regenerate after protoc installation.